### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/AnotherAssembly/AnotherAssembly.csproj
+++ b/AnotherAssembly/AnotherAssembly.csproj
@@ -3,7 +3,16 @@
     <PropertyGroup>
         <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
         <DisableFody>true</DisableFody>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\DeepCopy\DeepCopy.csproj" />
     </ItemGroup>

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <DisableFody>true</DisableFody>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AnotherAssembly\AnotherAssembly.csproj" />
     <ProjectReference Include="..\DeepCopy\DeepCopy.csproj" />

--- a/DeepCopy.Fody/DeepCopy.Fody.csproj
+++ b/DeepCopy.Fody/DeepCopy.Fody.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <DebugType>portable</DebugType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.1.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/DeepCopy/DeepCopy.csproj
+++ b/DeepCopy/DeepCopy.csproj
@@ -12,7 +12,15 @@
     <PackageOutputPath>$(SolutionDir)nugets</PackageOutputPath>
     <PackageProjectUrl>https://github.com/greuelpirat/DeepCopy</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/greuelpirat/DeepCopy/master/package_icon.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="None" />
     <PackageReference Include="FodyPackaging" Version="6.1.1" PrivateAssets="All" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
